### PR TITLE
Fix bug wiping out buffers when switching sessions

### DIFF
--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -123,9 +123,7 @@ function! s:OpenSession(name)
 		try
 			set eventignore=all
 			execute 'silent! ' . s:firstbuf() . ',' . bufnr('$') . 'bwipeout!'
-			let n = bufnr('%')
 			execute 'silent! so ' . s:sessions_path . '/' . a:name
-			execute 'silent! bwipeout! ' . n
 		finally
 			set eventignore=
 			doautoall BufRead

--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -67,6 +67,9 @@
 "  If 'sessionman_save_on_exit != 0' (default) then the current editing
 "  session will be automatically saved when you exit Vim.
 "
+"  If 'sessionman_minimal_ui != 0' (efault is 0) then the help that shows
+"  normal mode mappings will not be included in the sessions list
+"
 "  Plug-in creates a "Sessions" sub-menu under the "File" menu.
 "
 "============================================================================"
@@ -78,6 +81,10 @@ let loaded_sessionman = 1
 
 if !exists('sessionman_save_on_exit')
 	let sessionman_save_on_exit = 1
+endif
+
+if !exists('sessionman_minimal_ui')
+	let sessionman_minimal_ui = 0
 endif
 
 let s:cpo_save = &cpo
@@ -215,15 +222,17 @@ function! s:ListSessions()
 	nnoremap <buffer> <silent> e :call <SID>EditSession(getline('.'))<CR>
 	nnoremap <buffer> <silent> x :call <SID>EditSessionExtra(getline('.'))<CR>
 
-	syn match Comment "^\".*"
-	put ='\"-----------------------------------------------------'
-	put ='\" q                        - close session list'
-	put ='\" o, <CR>, <2-LeftMouse>   - open session'
-	put ='\" d                        - delete session'
-	put ='\" e                        - edit session'
-	put ='\" x                        - edit extra session script'
-	put ='\"-----------------------------------------------------'
-	put =''
+	if !g:sessionman_minimal_ui
+		syn match Comment "^\".*"
+		put ='\"-----------------------------------------------------'
+		put ='\" q                        - close session list'
+		put ='\" o, <CR>, <2-LeftMouse>   - open session'
+		put ='\" d                        - delete session'
+		put ='\" e                        - edit session'
+		put ='\" x                        - edit extra session script'
+		put ='\"-----------------------------------------------------'
+		put =''
+	endif
 	let l = line(".")
 
 	let sessions = readdirex(s:sessions_path)

--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -112,7 +112,7 @@ function! s:OpenSession(name)
 		endif
 		try
 			set eventignore=all
-			execute 'silent! %bwipeout!'
+			execute 'silent! 1,' . bufnr('$') . 'bwipeout!'
 			let n = bufnr('%')
 			execute 'silent! so ' . s:sessions_path . '/' . a:name
 			execute 'silent! bwipeout! ' . n
@@ -136,7 +136,7 @@ endfunction
 
 function! s:CloseSession()
 	call s:RestoreDefaults()
-	execute 'silent! %bwipeout!'
+	execute 'silent! 1,' . bufnr('$') . 'bwipeout!'
 	if has('cscope')
 		silent! cscope kill -1
 	endif

--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -94,6 +94,16 @@ let s:et_save = &et
 let s:sw_save = &sw
 let s:ts_save = &ts
 
+function! s:firstbuf()
+	for b in range(1, bufnr('$'))
+		if buflisted(b)
+			let l:firstbuf = b
+			break
+		endif
+	endfor
+	return l:firstbuf
+endfunction
+
 "============================================================================"
 
 function! s:RestoreDefaults()
@@ -112,7 +122,7 @@ function! s:OpenSession(name)
 		endif
 		try
 			set eventignore=all
-			execute 'silent! 1,' . bufnr('$') . 'bwipeout!'
+			execute 'silent! ' . s:firstbuf() . ',' . bufnr('$') . 'bwipeout!'
 			let n = bufnr('%')
 			execute 'silent! so ' . s:sessions_path . '/' . a:name
 			execute 'silent! bwipeout! ' . n
@@ -136,7 +146,7 @@ endfunction
 
 function! s:CloseSession()
 	call s:RestoreDefaults()
-	execute 'silent! 1,' . bufnr('$') . 'bwipeout!'
+	execute 'silent! ' . s:firstbuf() . ',' . bufnr('$') . 'bwipeout!'
 	if has('cscope')
 		silent! cscope kill -1
 	endif

--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -226,13 +226,14 @@ function! s:ListSessions()
 	put =''
 	let l = line(".")
 
-	let sessions = substitute(glob(s:sessions_path . '/*'), '\\', '/', 'g')
-	let sessions = substitute(sessions, "\\(^\\|\n\\)" . s:sessions_path . '/', '\1', 'g')
-	let sessions = substitute(sessions, "\n[^\n]\\+x\\.vim\n", '\n', 'g')
-	if sessions == ''
+	let sessions = readdirex(s:sessions_path)
+	if empty(sessions)
 		syn match Error "^\" There.*"
 		let sessions = '" There are no saved sessions'
 	endif
+	let sessions = sessions->sort(
+		\ {x, y -> x['time'] == y['time'] ? 0 : x['time'] < y['time'] ? 1 : -1}
+		\ )->map("v:val['name']")
 	silent put =sessions
 
 	0,1d

--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -83,10 +83,6 @@ if !exists('sessionman_save_on_exit')
 	let sessionman_save_on_exit = 1
 endif
 
-if !exists('sessionman_save_unloaded')
-	let sessionman_save_unloaded = !&hidden
-endif
-
 if !exists('sessionman_minimal_ui')
 	let sessionman_minimal_ui = 0
 endif
@@ -135,11 +131,6 @@ function! s:OpenSession(name)
 			set eventignore=all
 			execute 'silent! ' . s:firstbuf() . ',' . bufnr('$') . 'bwipeout!'
 			execute 'silent! so ' . s:sessions_path . '/' . a:name
-			if !g:sessionman_save_unloaded
-				let startbuf = bufnr()
-				silent! bufdo call bufload(bufnr())
-				execute 'silent! b' startbuf
-			endif
 		finally
 			set eventignore=
 			doautoall BufRead
@@ -269,12 +260,6 @@ function! s:SaveSessionAs(...)
 		let name = a:1
 	endif
 	if name != ''
-		if !g:sessionman_save_unloaded
-			let unloaded = filter(getbufinfo(), {_, v -> !v.loaded && !v.hidden && v.listed})
-			if !empty(unloaded)
-				execute 'bdelete' join(map(unloaded, {_, v -> v.bufnr}))
-			endif
-		endif
 		if v:version >= 700 && finddir(s:sessions_path, '/') == ''
 			call mkdir(s:sessions_path, 'p')
 		endif


### PR DESCRIPTION
Since v1.07 the commands to wipe out buffers when opening and closing
sessions have not worked reliably because they use the percent range to
run the bwipeout command, which does not wipe out all buffers, it just
wipes out buffers within the % range, i.e. the line numbers in the
current buffer.

When using the session list to switch between sessions, buffer numbers
soon become larger than the number of lines in the session list. Once
this happens, buffers are no longer wiped out when switching sessions.

Fixed by simply restoring the code from v1.06, which worked fine.
