### PR TITLE
Fixed the last session extra scripts still printed on __SessionList__

### DIFF
--- a/plugin/sessionman.vim
+++ b/plugin/sessionman.vim
@@ -221,6 +221,7 @@ function! s:ListSessions()
 	let sessions = substitute(glob(s:sessions_path . '/*'), '\\', '/', 'g')
 	let sessions = substitute(sessions, "\\(^\\|\n\\)" . s:sessions_path . '/', '\1', 'g')
 	let sessions = substitute(sessions, "\n[^\n]\\+x\\.vim\n", '\n', 'g')
+	let sessions = substitute(sessions, "\n[^\n]\\+x\\.vim", '\n', 'e')
 	if sessions == ''
 		syn match Error "^\" There.*"
 		let sessions = '" There are no saved sessions'


### PR DESCRIPTION
This PR fixed session with extra scripts, the last file can not be filtered.  Below is the sample:

The files:
```
➜  [/Users/gpadmin/.vim/sessions] ls
hawq2            hawq2x.vim       postgres         postgres-xl      postgres-xlx.vim postgresx.vim
```

The session list window shows as below: 
```
  1 "-----------------------------------------------------
  2 " q                        - close session list
  3 " o, <CR>, <2-LeftMouse>   - open session
  4 " d                        - delete session
  5 " e                        - edit session
  6 " x                        - edit extra session script
  7 "-----------------------------------------------------
  8
  9 hawq2
 10 postgres
 11 postgres-xl
 12 postgresx.vim
```

We need to filter the last item which is a session extra script.